### PR TITLE
Ocvl 195 new node get structuring element

### DIFF
--- a/nodes/imgproc/image_filtering/cv_getStructuringElement.py
+++ b/nodes/imgproc/image_filtering/cv_getStructuringElement.py
@@ -9,6 +9,13 @@ class OCVLgetStructuringElementNode(OCVLNodeBase):
     n_note = "When using OpenCV 1.x C API, the created structuring element IplConvKernel* element must be released in the end using cvReleaseStructuringElement(&element)."
     n_requirments = {}
 
+    SDEPTH_ITEMS = (
+    ("None", "None", "None", "", 0),
+    ("CV_32S", "CV_32S", "CV_32S", "", 1),
+    ("CV_32F", "CV_32F", "CV_32F", "", 2),
+    ("CV_64F", "CV_64F", "CV_64F", "", 3),
+    ("CV_32S", "CV_32S", "CV_32S", "", 1))
+
     def set_ksize(self, value):
         if value % 2 == 0:
             value = value + 1
@@ -17,25 +24,28 @@ class OCVLgetStructuringElementNode(OCVLNodeBase):
     def get_ksize(self):
         return self.get("ksize_in", 5)
 
-    shape_in: bpy.props.EnumProperty()#Co tu wwpisać do nawiasu?
+    shape_in: bpy.props.EnumProperty(items = SDEPTH_ITEMS,default = 3,update = update_node)
     anchor_in: bpy.props.IntVectorProperty(default=(-1, -1), update=update_node, size=2, description="Position of the anchor within the element.")
     ksize_in: bpy.props.IntProperty(default=5, update=update_node, min=1, max=30, get=get_ksize, set=set_ksize,description="Size of the structuring element.")
 
     def init(self, context):
         self.inputs.new('StringsSocket', "ksize_in").prop_name = 'ksize_in'
         self.inputs.new('StringsSocket', "anchor_in").prop_name = 'anchor_in'
+        self.inputs.new('StringSocket', "shape_in")
 
         self.outputs.new("ImageSocket", "retval_out")
 
     def wrapped_process(self):
         kwargs = {
             'ksize_in': self.get_from_props("ksize_in"),
-            'anchor_in': self.get_from_props("anchor_in")
+            'anchor_in': self.get_from_props("anchor_in"),
+            'shape_in': self.get_from_props("shape_in"),
         }
 
         retval_out = self.process_cv(fn=cv2.getStructuringElement, kwargs=kwargs)
         self.refresh_output_socket("retval_output", retval_out, is_uuid_type=True)
 
     def draw_buttons(self, context, layout):
+        self.add_button(layout, 'borderType_in')
         self.add_button(layout, 'borderType_in')
         self.add_button(layout, 'borderType_in')

--- a/nodes/imgproc/image_filtering/cv_getStructuringElement.py
+++ b/nodes/imgproc/image_filtering/cv_getStructuringElement.py
@@ -1,0 +1,37 @@
+import uuid
+
+import bpy
+import cv2
+from ocvl.core.node_base import OCVLNodeBase, update_node, BORDER_TYPE_ITEMS
+
+class OCVLgetStructuringElementNode(OCVLNodeBase):
+    n_doc = "The function constructs and returns the structuring element that can be further passed to erode(), dilate() or morphologyEx() . But you can also construct an arbitrary binary mask yourself and use it as the structuring element."
+    n_note = "When using OpenCV 1.x C API, the created structuring element IplConvKernel* element must be released in the end using cvReleaseStructuringElement(&element)."
+    n_requirments = {}
+
+    def set_ksize(self, value):
+        if value % 2 == 0:
+            value = value + 1
+        self["ksize_in"] = value
+
+    def get_ksize(self):
+        return self.get("ksize_in", 5)
+
+    ksize_in: bpy.props.IntProperty(default=5, update=update_node, min=1, max=30, get=get_ksize, set=set_ksize,description="Size of the structuring element.")
+
+    def init(self, context):
+        self.inputs.new('StringsSocket', "ksize_in").prop_name = 'ksize_in'
+
+        self.outputs.new("ImageSocket", "retval_out")
+
+    def wrapped_process(self):
+        kwargs = {
+            'ksize_in': self.get_from_props("ksize_in"),
+        }
+
+        dst_out = self.process_cv(fn=cv2.getStructuringElement, kwargs=kwargs)
+        self.refresh_output_socket("retval_output", dst_out, is_uuid_type=True)
+
+    def draw_buttons(self, context, layout):
+        self.add_button(layout, 'borderType_in')
+        self.add_button(layout, 'borderType_in')

--- a/nodes/imgproc/image_filtering/cv_getStructuringElement.py
+++ b/nodes/imgproc/image_filtering/cv_getStructuringElement.py
@@ -17,20 +17,24 @@ class OCVLgetStructuringElementNode(OCVLNodeBase):
     def get_ksize(self):
         return self.get("ksize_in", 5)
 
+    shape_in: bpy.props.EnumProperty()#Co tu wwpisać do nawiasu?
+    anchor_in: bpy.props.IntVectorProperty(default=(-1, -1), update=update_node, size=2, description="Position of the anchor within the element.")
     ksize_in: bpy.props.IntProperty(default=5, update=update_node, min=1, max=30, get=get_ksize, set=set_ksize,description="Size of the structuring element.")
 
     def init(self, context):
         self.inputs.new('StringsSocket', "ksize_in").prop_name = 'ksize_in'
+        self.inputs.new('StringsSocket', "anchor_in").prop_name = 'anchor_in'
 
         self.outputs.new("ImageSocket", "retval_out")
 
     def wrapped_process(self):
         kwargs = {
             'ksize_in': self.get_from_props("ksize_in"),
+            'anchor_in': self.get_from_props("anchor_in")
         }
 
-        dst_out = self.process_cv(fn=cv2.getStructuringElement, kwargs=kwargs)
-        self.refresh_output_socket("retval_output", dst_out, is_uuid_type=True)
+        retval_out = self.process_cv(fn=cv2.getStructuringElement, kwargs=kwargs)
+        self.refresh_output_socket("retval_output", retval_out, is_uuid_type=True)
 
     def draw_buttons(self, context, layout):
         self.add_button(layout, 'borderType_in')

--- a/nodes/imgproc/image_filtering/cv_medianBlur.py
+++ b/nodes/imgproc/image_filtering/cv_medianBlur.py
@@ -1,0 +1,42 @@
+import uuid
+
+import bpy
+import cv2
+from ocvl.core.node_base import OCVLNodeBase, update_node, BORDER_TYPE_ITEMS
+
+class OCVLmedianBlurNode(OCVLNodeBase):
+    n_doc = "The function smoothes an image using the median filter with the texttt{ksize} times texttt{ksize} aperture. Each channel of a multi-channel image is processed independently. In-place operation is supported."
+    n_see_also = "bileteralFilter,blur,boxFilter,GaussianBlur"
+    n_requirements = {"__and__": ["src_in"]}
+
+    def set_ksize(self, value):
+        if value % 2 == 0:
+            value = value + 1
+        self["ksize_in"] = value
+
+    def get_ksize(self):
+        return self.get("ksize_in", 5)
+
+    src_in: bpy.props.StringProperty(name="src_in", default=str(uuid.uuid4()), description="Input 1-, 3-, or 4-channel image; when ksize is 3 or 5, the image depth should be CV_8U, CV_16U, or CV_32F, for larger aperture sizes, it can only be CV_8U.")
+    ksize_in: bpy.props.IntProperty(default=5, update=update_node, min=1, max=30, get=get_ksize, set=set_ksize,description="Aperture linear size; it must be odd and greater than 1, for example: 3, 5, 7 ...")
+
+    dst_out: bpy.props.StringProperty(name="dst_out", default=str(uuid.uuid4()),description="Destination array of the same size and type as src.")
+
+    def init(self, context):
+        self.inputs.new("ImageSocket", "src_in")
+        self.inputs.new('StringsSocket', "ksize_in").prop_name = 'ksize_in'
+
+        self.outputs.new("ImageSocket", "dst_out")
+
+    def wrapped_process(self):
+        kwargs = {
+            'src': self.get_from_props("src_in"),
+            'ksize_in': self.get_from_props("ksize_in"),
+        }
+
+        dst_out = self.process_cv(fn=cv2.medianBlur, kwargs=kwargs)
+        self.refresh_output_socket("dst_out", dst_out, is_uuid_type=True)
+
+    def draw_buttons(self, context, layout):
+        self.add_button(layout, 'borderType_in') 
+        self.add_button(layout, 'borderType_in') 


### PR DESCRIPTION
import uuid

import bpy
import cv2
from ocvl.core.node_base import OCVLNodeBase, update_node, BORDER_TYPE_ITEMS

class OCVLgetStructuringElementNode(OCVLNodeBase):
    n_doc = "The function constructs and returns the structuring element that can be further passed to erode(), dilate() or morphologyEx() . But you can also construct an arbitrary binary mask yourself and use it as the structuring element."
    n_note = "When using OpenCV 1.x C API, the created structuring element IplConvKernel* element must be released in the end using cvReleaseStructuringElement(&element)."
    n_requirments = {}

    def set_ksize(self, value):
        if value % 2 == 0:
            value = value + 1
        self["ksize_in"] = value

    def get_ksize(self):
        return self.get("ksize_in", 5)

    shape_in: bpy.props.EnumProperty()#Co tu wwpisać do nawiasu?
    anchor_in: bpy.props.IntVectorProperty(default=(-1, -1), update=update_node, size=2, description="Position of the anchor within the element.")
    ksize_in: bpy.props.IntProperty(default=5, update=update_node, min=1, max=30, get=get_ksize, set=set_ksize,description="Size of the structuring element.")

    def init(self, context):
        self.inputs.new('StringsSocket', "ksize_in").prop_name = 'ksize_in'
        self.inputs.new('StringsSocket', "anchor_in").prop_name = 'anchor_in'

        self.outputs.new("ImageSocket", "retval_out")

    def wrapped_process(self):
        kwargs = {
            'ksize_in': self.get_from_props("ksize_in"),
            'anchor_in': self.get_from_props("anchor_in")
        }

        retval_out = self.process_cv(fn=cv2.getStructuringElement, kwargs=kwargs)
        self.refresh_output_socket("retval_output", retval_out, is_uuid_type=True)

    def draw_buttons(self, context, layout):
        self.add_button(layout, 'borderType_in')
        self.add_button(layout, 'borderType_in')